### PR TITLE
can run drush cc all again

### DIFF
--- a/includes/object.entity_controller.inc
+++ b/includes/object.entity_controller.inc
@@ -31,7 +31,9 @@ class IslandoraObjectEntityController implements DrupalEntityControllerInterface
    * @return array
    *   An array of loaded objects.
    */
-  public function load(array $ids = array(), array $conditions = array()) {
+  // @codingStandardsIgnoreStart
+  public function load($ids = array(), $conditions = array()) {
+  // @codingStandardsIgnoreEnd
     if (!empty($conditions)) {
       // TODO: Allow loading by specifying IDs in the condition.
       throw new Exception('Conditions not implemented.');


### PR DESCRIPTION
I pulled this down and ran `drush cc all` got an error with ```Fatal error: Declaration of IslandoraObjectEntityController::load() must be compatible with DrupalEntityControllerInterface::load($ids = Array, $conditions = Array) in /var/www/drupal7/sites/all/modules/islandora/includes/object.entity_controller.inc on line 11``` in it.